### PR TITLE
Support 1st person recording. Adding logging and timers.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
 import ora.gui as Gui
-# import pdb
 
 def main():
-    # pdb.set_trace()
     Gui.gui_instance.show()
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import ora.gui as Gui
+# import pdb
 
 def main():
+    # pdb.set_trace()
     Gui.gui_instance.show()
 
 if __name__ == '__main__':

--- a/main_cli.py
+++ b/main_cli.py
@@ -6,7 +6,7 @@ def main():
     program.run()
 
 if __name__ == '__main__':
-    logging.getLogger().setLevel(logging.INFO)
+    logging.getLogger().setLevel(logging.DEBUG)
     pool.initPool()
 
     main()

--- a/ora/command_line.py
+++ b/ora/command_line.py
@@ -51,7 +51,7 @@ class Program(object):
             Mandatory arguments:
                 F:/video.mp4         Absolute path of video
                 F:/                  Absolute path of output file
-                0                    A number representing game type. 0: OWL, 1: Non-OWL
+                0                    A number representing game type. 0: OWL, 1: Non-OWL, 2: 1st person
 
             Optional:
                 players=players.txt  A text file saving info of all 12 players with JSON formatting
@@ -132,20 +132,20 @@ class Program(object):
         except ValueError:
             log('Invalid game type!')
 
-        if not (info['game_type'] == 0 or info['game_type'] == 1):
+        if not (info['game_type'] >= 0 and info['game_type'] <= 2):
             raise ValueError('Invalid game type!')
         return info
 
     def run(self):
         info = self.info()
-        game_type = OW.GAMETYPE_OWL if info['game_type'] == 0 else OW.GAMETYPE_CUSTOM
-        self.game_instance = game.Game(game_type)
+        # game_type = OW.GAMETYPE_OWL if info['game_type'] == 0 else OW.GAMETYPE_CUSTOM
+        self.game_instance = game.Game(info['game_type'])
         self.game_instance.set_game_info(info)
         self.game_instance.analyze(info['start_time'], info['end_time'], is_test=False)
         pool.PROCESS_POOL.close()
         pool.PROCESS_POOL.join()
-        self.game_instance.output_to_json()
-        self.game_instance.output_to_excel()
+        # self.game_instance.output_to_json()
+        # self.game_instance.output_to_excel()
         log('ok')
 
 program = Program()

--- a/ora/command_line.py
+++ b/ora/command_line.py
@@ -151,7 +151,7 @@ class Program(object):
             game_type = OW.GAMETYPE_CUSTOM
         else:
             game_type = OW.GAMETYPE_1ST
-        self.game_instance = game.Game(info['game_type'])
+        self.game_instance = game.Game(game_type)
         self.game_instance.set_game_info(info)
         self.game_instance.analyze(info['start_time'], info['end_time'], is_test=False)
         pool.PROCESS_POOL.close()

--- a/ora/frame.py
+++ b/ora/frame.py
@@ -57,18 +57,19 @@ class Frame(object):
         # Gui.gui_instance.show_progress(self.time)
 
         print(self.time)
+        # cv2.imshow('t',self.image)
+        # cv2.waitKey(0)
         if self.game_type != OW.GAMETYPE_1ST:
             self.get_players() # Costs 246ms on i5
             logging.debug('get_players time: %d ms', (time.time() - self.current_time) * 1000)
             self.current_time = time.time()
-
         self.get_killfeeds() # Costs 38ms on i5
         logging.debug('get_killfeeds time: %d ms', (time.time() - self.current_time) * 1000)
         self.current_time = time.time()
-
         self.validate() # Costs 3ms on i5
         logging.debug('validate time: %d ms', (time.time() - self.current_time) * 1000)
         self.current_time = time.time()
+
 
         self.free() # Costs 0ms on i5
         logging.debug('free time: %d ms', (time.time() - self.current_time) * 1000)
@@ -106,17 +107,13 @@ class Frame(object):
             None 
         """
         # Multiprocess players
-
         game_type = self.game_type
         game_version = self.game_version
         image = self.image
         ult_charge_numbers_ref = self.game.ult_charge_numbers_ref
         results = []
-
         for i in range(0, 12):
-            # current_time = time.time()
             avatars = self.get_avatars(i) # 12ms each, or 0 after 1st time.
-            # print("--- get_avatars %s ms ---" % ((time.time() - current_time) * 1000))
             team = -1
 
             if i < 6:
@@ -124,13 +121,11 @@ class Frame(object):
             else:
                 team = self.game.team_names[OW.RIGHT]
 
-            self.players[i] = Player(i, avatars, team, image, game_type, game_version, ult_charge_numbers_ref, self.time)
-            # results.append(pool.PROCESS_POOL.apply_async(Player, 
-            #     args=(i, avatars, team, image, game_type, game_version, ult_charge_numbers_ref, self.time),
-            #     callback=self.player_callback))
-        
-        # for res in results:
-        #     res.wait()
+            results.append(pool.PROCESS_POOL.apply_async(Player, 
+                args=(i, avatars, team, image, game_type, game_version, ult_charge_numbers_ref, self.time),
+                callback=self.player_callback))
+        for res in results:
+            res.wait()
         
     def get_team_colors_from_image(self):
         """Get team colors from this frame.

--- a/ora/gui.py
+++ b/ora/gui.py
@@ -165,6 +165,8 @@ You can contact the author or report issues by: https://github.com/appcell/Overw
         }
 
     def info(self):
+        # Extract information from GUI. 
+        # Read time configuration, player names and validate user input.
         valid = True
         info = {
             "name_team_left": "left",
@@ -253,22 +255,26 @@ You can contact the author or report issues by: https://github.com/appcell/Overw
 
     def run(self):
         info, valid = self.info()
+        if not valid:
+            print('Invalid user input.')
+            return
+
         game_type = OW.GAMETYPE_OWL if info['game_type'] == 0 else OW.GAMETYPE_CUSTOM
         self.game_instance = game.Game(game_type)
-        if valid is True:
-            self.game_instance.set_game_info(info)
-            pool.initPool()
+        self.game_instance.set_game_info(info)
 
-            try:
-                self.game_instance.analyze(info['start_time'], info['end_time'], is_test=False)
-            except Exception as err:
-                print(err)
-            else:
-                self.game_instance.output_to_json()
-                self.game_instance.output_to_excel()
-                self.show_finish_msg()
-                
-            pool.PROCESS_POOL.close()
-            pool.PROCESS_POOL.join()
+        pool.initPool()
+
+        try:
+            self.game_instance.analyze(info['start_time'], info['end_time'], is_test=True)
+        except Exception as err:
+            print(err)
+        else:
+            self.game_instance.output_to_json()
+            self.game_instance.output_to_excel()
+            self.show_finish_msg()
+            
+        pool.PROCESS_POOL.close()
+        pool.PROCESS_POOL.join()
 
 gui_instance = Gui()

--- a/ora/killfeed.py
+++ b/ora/killfeed.py
@@ -239,6 +239,10 @@ class Killfeed:
             edge_image = cv2.Canny(self.image, 100, 200)
             # Get the "spanned" edge image.
             edge_span = (edge_image.sum(0) + np.roll(edge_image.sum(0), 1))/255
+        elif self.game_type == OW.GAMETYPE_1ST:
+            edge_image = cv2.Canny(self.image, 100, 200)
+            # Get the "spanned" edge image.
+            edge_span = (edge_image.sum(0) + np.roll(edge_image.sum(0), 1))/255           
 
         return edge_span
 

--- a/ora/killfeed.py
+++ b/ora/killfeed.py
@@ -73,7 +73,8 @@ class Killfeed:
         self.image = ImageUtils.crop(frame.image, killfeed_pos)
         self.image_with_gap = ImageUtils.crop(
             frame.image, killfeed_with_gap_pos)
-
+        # cv2.imshow('t', self.image)
+        # cv2.waitKey(0)
         self.get_players()
         self.get_ability_and_assists()
         self.get_headshot()
@@ -129,7 +130,6 @@ class Killfeed:
             self.is_valid = False
             logging.debug('Did not find any icons')
             return
-
         # Differentiate results from 2 sides first, or it gets seriously wrong
         mean_pos = np.mean([i['pos'] for i in icons_weights])
         icons_weights_left = [i for i in icons_weights if i['pos'] < mean_pos]
@@ -273,11 +273,6 @@ class Killfeed:
             'team': -1,
             'player': -1,
             'pos': player['pos']}
-        # At least red or blue
-        # if self.game_type == OW.GAMETYPE_1ST:
-        #     # No player info is available in 1st recording.
-        #     res['team'] = position
-        #     return res
         color_pos = OW.get_killfeed_team_color_pos(
             player['pos'], position, self.game_type, self.game_version)
         logging.debug('player pos:%d color_pos, y:%d, x:%d', player['pos'], color_pos[0], color_pos[1])

--- a/ora/overwatch.py
+++ b/ora/overwatch.py
@@ -18,6 +18,7 @@ import numpy as np
 # **********************************************************
 GAMETYPE_OWL = 0
 GAMETYPE_CUSTOM = 1
+GAMETYPE_1ST = 2
 ANALYZER_FPS = 2
 DEFAULT_SCREEN_WIDTH = 1280
 DEFAULT_SCREEN_HEIGHT = 720
@@ -529,6 +530,9 @@ ULT_CHARGE_IMG_WIDTH = {
     },
     GAMETYPE_CUSTOM: {
         0: 6
+    },
+    GAMETYPE_1ST: {
+        0: 6
     }
 }
 ULT_CHARGE_IMG_WIDTH_OBSERVED = {
@@ -537,6 +541,9 @@ ULT_CHARGE_IMG_WIDTH_OBSERVED = {
         1: 7
     },
     GAMETYPE_CUSTOM: {
+        0: 7
+    },
+    GAMETYPE_1ST: {
         0: 7
     }
 }
@@ -548,6 +555,9 @@ ULT_CHARGE_IMG_HEIGHT = {
     },
     GAMETYPE_CUSTOM: {
         0: 16
+    },
+    GAMETYPE_1ST: {
+        0: 16
     }
 }
 ULT_CHARGE_IMG_HEIGHT_OBSERVED = {
@@ -556,6 +566,9 @@ ULT_CHARGE_IMG_HEIGHT_OBSERVED = {
         1: 18
     },
     GAMETYPE_CUSTOM: {
+        0: 18
+    },
+    GAMETYPE_1ST: {
         0: 18
     }
 }
@@ -914,6 +927,9 @@ KILLFEED_ICON_HEIGHT = {
     },
     GAMETYPE_CUSTOM: {
         0: 21
+    },
+    GAMETYPE_1ST: {
+        0: 21
     }
 }
 KILLFEED_ICON_WIDTH = {
@@ -922,6 +938,9 @@ KILLFEED_ICON_WIDTH = {
         1: 31
     },
     GAMETYPE_CUSTOM: {
+        0: 31
+    },
+    GAMETYPE_1ST: {
         0: 31
     }
 }
@@ -933,6 +952,9 @@ KILLFEED_ICON_EDGE_HEIGHT_RATIO_LEFT = {
     },
     GAMETYPE_CUSTOM: {
         0: 0.7
+    },
+    GAMETYPE_1ST: {
+        0: 0.7
     }
 }
 KILLFEED_ICON_EDGE_HEIGHT_RATIO_RIGHT = {
@@ -941,6 +963,9 @@ KILLFEED_ICON_EDGE_HEIGHT_RATIO_RIGHT = {
         1: 0.7
     },
     GAMETYPE_CUSTOM: {
+        0: 0.7
+    },
+    GAMETYPE_1ST: {
         0: 0.7
     }
 }
@@ -952,6 +977,9 @@ KILLFEED_WIDTH = {
     },
     GAMETYPE_CUSTOM: {
         0: 320
+    },
+    GAMETYPE_1ST: {
+        0: 320
     }
 }
 KILLFEED_RIGHT_WIDTH = {
@@ -960,6 +988,9 @@ KILLFEED_RIGHT_WIDTH = {
         1: 140
     },
     GAMETYPE_CUSTOM: {
+        0: 140
+    },
+    GAMETYPE_1ST: {
         0: 140
     }
 }
@@ -971,6 +1002,9 @@ KILLFEED_X_MIN = {
     },
     GAMETYPE_CUSTOM: {
         0: 963
+    },
+    GAMETYPE_1ST: {
+        0: 963
     }
 }
 KILLFEED_Y_MIN = {
@@ -979,6 +1013,9 @@ KILLFEED_Y_MIN = {
         1: 114 + 25
     },
     GAMETYPE_CUSTOM: {
+        0: 114
+    },
+    GAMETYPE_1ST: {
         0: 114
     }
 }
@@ -989,6 +1026,9 @@ KILLFEED_WIDTH = {
     },
     GAMETYPE_CUSTOM: {
         0: 320
+    },
+    GAMETYPE_1ST: {
+        0: 320
     }
 }
 KILLFEED_HEIGHT = {
@@ -998,6 +1038,9 @@ KILLFEED_HEIGHT = {
     },
     GAMETYPE_CUSTOM: {
         0: 27
+    },
+    GAMETYPE_1ST: {
+        0: 27
     }
 }
 KILLFEED_GAP = {
@@ -1006,6 +1049,9 @@ KILLFEED_GAP = {
         1: 35
     },
     GAMETYPE_CUSTOM: {
+        0: 35
+    },
+    GAMETYPE_1ST: {
         0: 35
     }
 }
@@ -1017,6 +1063,9 @@ KILLFEED_MAX_PROB = {
     },
     GAMETYPE_CUSTOM: {
         0: 0.6
+    },
+    GAMETYPE_1ST: {
+        0: 0.6
     }
 }
 KILLFEED_SSIM_THRESHOLD = {
@@ -1025,6 +1074,9 @@ KILLFEED_SSIM_THRESHOLD = {
         1: 0.35
     },
     GAMETYPE_CUSTOM: {
+        0: 0.35
+    },
+    GAMETYPE_1ST: {
         0: 0.35
     }
 }
@@ -1035,6 +1087,9 @@ KILLFEED_MAX_COLOR_DISTANCE = {
     },
     GAMETYPE_CUSTOM: {
         0: 120
+    },
+    GAMETYPE_1ST: {
+        0: 120
     }
 }
 KILLFEED_EDGE_MAX_COLOR_DISTANCE = {
@@ -1043,6 +1098,9 @@ KILLFEED_EDGE_MAX_COLOR_DISTANCE = {
         1: 30
     },
     GAMETYPE_CUSTOM: {
+        0: 80
+    },
+    GAMETYPE_1ST: {
         0: 80
     }
 }
@@ -1054,6 +1112,9 @@ KILLFEED_TEAM_COLOR_POS_Y = {
     },
     GAMETYPE_CUSTOM: {
         0: 2
+    },
+    GAMETYPE_1ST: {
+        0: 2
     }
 }
 
@@ -1064,6 +1125,9 @@ KILLFEED_TEAM_COLOR_POS_X_LEFT = {
     },
     GAMETYPE_CUSTOM: {
         0: -1
+    },
+    GAMETYPE_1ST: {
+        0: -1
     }
 }
 KILLFEED_TEAM_COLOR_POS_X_RIGHT = {
@@ -1072,6 +1136,9 @@ KILLFEED_TEAM_COLOR_POS_X_RIGHT = {
         1: 10
     },
     GAMETYPE_CUSTOM: {
+        0: 1
+    },
+    GAMETYPE_1ST: {
         0: 1
     }
 }
@@ -1185,6 +1252,9 @@ ABILITY_ICON_WIDTH = {
     },
     GAMETYPE_CUSTOM: {
         0: 26
+    },
+    GAMETYPE_1ST: {
+        0: 26
     }
 }
 ABILITY_ICON_HEIGHT = {
@@ -1193,6 +1263,9 @@ ABILITY_ICON_HEIGHT = {
         1: 26
     },
     GAMETYPE_CUSTOM: {
+        0: 26
+    },
+    GAMETYPE_1ST: {
         0: 26
     }
 }
@@ -1204,6 +1277,9 @@ ABILITY_ICON_REF_WIDTH = {
     },
     GAMETYPE_CUSTOM: {
         0: 22
+    },
+    GAMETYPE_1ST: {
+        0: 22
     }
 }
 ABILITY_ICON_REF_HEIGHT = {
@@ -1212,6 +1288,9 @@ ABILITY_ICON_REF_HEIGHT = {
         1: 22
     },
     GAMETYPE_CUSTOM: {
+        0: 22
+    },
+    GAMETYPE_1ST: {
         0: 22
     }
 }
@@ -1223,6 +1302,9 @@ ABILITY_ICON_COLOR_FILTER_THRESHOLD = {
     },
     GAMETYPE_CUSTOM: {
         0: 70
+    },
+    GAMETYPE_1ST: {
+        0: 70
     }
 }
 
@@ -1233,6 +1315,9 @@ ABILITY_GAP_ICON = {
     },
     GAMETYPE_CUSTOM: {
         0: 26
+    },
+    GAMETYPE_1ST: {
+        0: 26
     }
 }
 ABILITY_GAP_NORMAL = {
@@ -1241,6 +1326,9 @@ ABILITY_GAP_NORMAL = {
         1: 30
     },
     GAMETYPE_CUSTOM: {
+        0: 30
+    },
+    GAMETYPE_1ST: {
         0: 30
     }
 }
@@ -1252,6 +1340,9 @@ ASSIST_ICON_Y_MIN = {
     },
     GAMETYPE_CUSTOM: {
         0: 6
+    },
+    GAMETYPE_1ST: {
+        0: 6
     }
 }
 ABILITY_ICON_Y_MIN = {
@@ -1260,6 +1351,9 @@ ABILITY_ICON_Y_MIN = {
         1: 2
     },
     GAMETYPE_CUSTOM: {
+        0: 2
+    },
+    GAMETYPE_1ST: {
         0: 2
     }
 }
@@ -1270,6 +1364,9 @@ ABILITY_ICON_X_MIN = {
         1: -23
     },
     GAMETYPE_CUSTOM: {
+        0: -23
+    },
+    GAMETYPE_1ST: {
         0: -23
     }
 }
@@ -1331,6 +1428,9 @@ ASSIST_GAP = {
     },
     GAMETYPE_CUSTOM: {
         0: 18
+    },
+    GAMETYPE_1ST: {
+        0: 18
     }
 }
 
@@ -1341,6 +1441,9 @@ ASSIST_ICON_HEIGHT = {
     },
     GAMETYPE_CUSTOM: {
         0: 18
+    },
+    GAMETYPE_1ST: {
+        0: 18
     }
 }
 ASSIST_ICON_WIDTH = {
@@ -1349,6 +1452,9 @@ ASSIST_ICON_WIDTH = {
         1: 12
     },
     GAMETYPE_CUSTOM: {
+        0: 12
+    },
+    GAMETYPE_1ST: {
         0: 12
     }
 }
@@ -1359,6 +1465,9 @@ ASSIST_ICON_X_OFFSET = {
         1: 8
     },
     GAMETYPE_CUSTOM: {
+        0: 8
+    },
+    GAMETYPE_1ST: {
         0: 8
     }
 }
@@ -1412,6 +1521,9 @@ FRAME_VALIDATION_EFFECT_TIME = {
     },
     GAMETYPE_CUSTOM: {
         0: 2.0
+    },
+    GAMETYPE_1ST: {
+        0: 2.0
     }
 }
 FRAME_VALIDATION_EFFECT_AFTER_TIME = {
@@ -1421,6 +1533,9 @@ FRAME_VALIDATION_EFFECT_AFTER_TIME = {
     },
     GAMETYPE_CUSTOM: {
         0: 0.7
+    },
+    GAMETYPE_1ST: {
+        0: 0.7
     }
 }
 FRAME_VALIDATION_REPLAY_PROB = {
@@ -1429,6 +1544,9 @@ FRAME_VALIDATION_REPLAY_PROB = {
         1: 0.5
     },
     GAMETYPE_CUSTOM: {
+        0: 0.5
+    },
+    GAMETYPE_1ST: {
         0: 0.5
     }
 }
@@ -1440,6 +1558,9 @@ REPLAY_ICON_POS = {
     },
     GAMETYPE_CUSTOM: {
         0: [111, 64, 64, 74]
+    },
+    GAMETYPE_1ST: {
+        0: [111, 64, 64, 74]
     }
 }
 
@@ -1449,6 +1570,9 @@ REPLAY_ICON_POS_PRESEASON = {
         1: [109, 66, 23, 74]
     },
     GAMETYPE_CUSTOM: {
+        0: [109, 66, 23, 74]
+    },
+    GAMETYPE_1ST: {
         0: [109, 66, 23, 74]
     }
 }

--- a/ora/player.py
+++ b/ora/player.py
@@ -6,8 +6,8 @@ from skimage import measure
 from . import overwatch as OW
 from .utils import image as ImageUtils
 
+import logging
 import time as t
-import matplotlib.pyplot as plt
 
 class Player:
     """Class of a Killfeed object.
@@ -73,15 +73,15 @@ class Player:
 
         # 60ms baseline
         self.get_ult_status() # 106ms or +0ms? 1ms each
-        print("--- get_ult_status %s ms ---" % ((t.time() - self.current_time) * 1000))
+        logging.debug('get_ult_status time: %d ms', (t.time() - self.current_time) * 1000)
         self.current_time = t.time()
 
         self.get_chara() # +130ms 44ms each
-        print("--- get_chara %s ms ---" % ((t.time() - self.current_time) * 1000))
+        logging.debug('get_chara time: %d ms', (t.time() - self.current_time) * 1000)
         self.current_time = t.time()
 
         self.get_ult_charge() # + 50ms 9/16 ms each
-        print("--- get_ult_charge %s ms ---" % ((t.time() - self.current_time) * 1000))
+        logging.debug('get_ult_charge time: %d ms', (t.time() - self.current_time) * 1000)
         self.current_time = t.time()
 
         self.free()
@@ -182,12 +182,6 @@ class Player:
             self.index, self.game_type, self.game_version))
         avatar = ImageUtils.crop(self.image, OW.get_avatar_pos(
             self.index, self.game_type, self.game_version))
-        # plt.subplot(211)
-        # plt.imshow(avatar_observed)
-        # plt.subplot(212)
-        # plt.imshow(avatar)
-        # plt.gray()
-        # plt.show()
 
         self._identify_is_observed(team_color)
         
@@ -212,8 +206,6 @@ class Player:
             temp_avatar = ImageUtils.crop(avatar, [loc[1], avatars_ref[
                                         name].shape[0], loc[0], avatars_ref[
                                         name].shape[1]])
-            # current_time = t.time()
-            # 1 or 0.5 ms
             s_ssim = measure.compare_ssim(
                         temp_avatar,
                         avatars_ref[name],
@@ -221,13 +213,10 @@ class Player:
             s_ssim_final = s_ssim_observed if s_ssim_observed > s_ssim else s_ssim
             s_final = s_observed if s_observed > s else s
             loc_final = loc_observed if s_observed > s else loc
-            # print("--- in get char %s ms ---" % ((t.time() - current_time) * 1000))
-            # current_time = t.time()
 
             if s_final*0.4 + s_ssim_final*0.6 > score:
                 score = s_final*0.4 + s_ssim_final*0.6
                 self.chara = name
-
 
         if self.chara is None:
             self.chara = "empty"
@@ -453,9 +442,6 @@ class Player:
                         if max_diff > 40:
                             return
         self.is_observed = True
-        # if max_diff < 40 and self.is_ult_ready is False:
-        #     self.is_observed = True
-        # print("--- is_observed %s ms ---" % ((t.time() - current_time) * 1000))
 
     def _identify_ult_charge_digit(self, digit, digit_refs):
         """Retrieves ultimate charge for current player.

--- a/ora/utils/video_loader.py
+++ b/ora/utils/video_loader.py
@@ -22,7 +22,7 @@ class VideoLoader:
         self.cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
         ret, frame = self.cap.read()
         if ret:
-            cv2.imwrite("frame%d.jpg" % self.count, frame)
+            # cv2.imwrite("frame%d.jpg" % self.count, frame)
             self.count +=1
             return frame
         else:


### PR DESCRIPTION
Feature: support 1st person recording (killfeeds only) and export results to json (no excel).

Clean up: adding logging and timers.
To see logs (timing info), change logging level to debug in main_cli.py. This should be passed in as a flag though.

Tested manually with OWL and 1st person mode. However I cannot see killfeeds from my OWL video even without my change. Looks like there is a small shift in Y-axis when capturing the killfeeds.